### PR TITLE
Add monitor selection dropdown to Appearance settings

### DIFF
--- a/Settings.cs
+++ b/Settings.cs
@@ -8,6 +8,7 @@ public class Settings
     public string ThemeOverride { get; set; } = "System";
     public bool Use24HourFormat { get; set; }
     public bool ShowBorder { get; set; }
+    public int Monitor { get; set; }
 
     public TimeZoneSettings[]? TimeZones { get; set; }
 


### PR DESCRIPTION
- Add Monitor property to Settings for persisting selected display
- Add GetTargetDisplayArea() helper using DisplayArea.FindAll()
- Update PositionOnTaskbar, drag, and FinishDrag to use configured monitor
- Add Monitor dropdown in settings with display resolution and primary label
- Live-update Position X/Y fields during drag and monitor switch
- Rename Layout to Position, increase settings window height